### PR TITLE
Deal & make robust with URL encoding

### DIFF
--- a/app/controllers/geturl.go
+++ b/app/controllers/geturl.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"log"
 	"net/http"
+	"net/url"
 
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/gin-gonic/gin"
@@ -11,7 +12,7 @@ import (
 
 func GetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		shortUrl := c.Param("shortUrl")
+		shortUrl := url.PathEscape(c.Param("shortUrl"))
 
 		// Redisに問い合わせてURLを取得
 		baseUrl, err := appCtx.Redis.GetBaseUrl(shortUrl)

--- a/app/controllers/seturl.go
+++ b/app/controllers/seturl.go
@@ -18,6 +18,14 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
+type NotAcceptableIdError struct {
+	Message string
+}
+
+func (naie *NotAcceptableIdError) Error() string {
+	return naie.Message
+}
+
 func SetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var r models.SetUrlRequest
@@ -114,6 +122,11 @@ func SetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 					return
 				}
 
+				// 受理可能なカスタムIDか
+				if err := checkAcceptableUrlId(customId); err != nil {
+					continue
+				}
+
 				// 生成されたカスタムIDがRedisに存在するか確認
 				customIdIsExists, err = appCtx.Redis.IsExists(customId)
 				if err != nil {
@@ -130,11 +143,11 @@ func SetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 				return
 			}
 		} else { // カスタムIDが指定されている場合
-			// `/` はGinの仕様上リダイレクト時に処理されないので禁止する
-			if strings.Contains(*r.CustomID, "/") {
+			// 受理可能なカスタムIDか
+			if err := checkAcceptableUrlId(*r.CustomID); err != nil {
 				c.JSON(http.StatusBadRequest, models.APIError{
 					Type:    "invalid_request",
-					Message: "custom_id contains `/`, it isn't acceptable.",
+					Message: fmt.Sprintf("custom_id: %s", err.Error()),
 				})
 
 				return
@@ -183,6 +196,17 @@ func setUrlHandlerCustomValidate(r *models.SetUrlRequest) *models.APIError {
 		return &models.APIError{
 			Type:    "parameter_conflict",
 			Message: "custom_id cannot be used together with use_uppercase, use_lowercase, use_numbers, or id_length",
+		}
+	}
+
+	return nil
+}
+
+func checkAcceptableUrlId(s string) error {
+	// `/` はGinの仕様上リダイレクト時に処理されないので禁止する
+	if strings.Contains(s, "/") {
+		return &NotAcceptableIdError{
+			Message: "contains `/`, it isn't acceptable.",
 		}
 	}
 

--- a/app/controllers/seturl.go
+++ b/app/controllers/seturl.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -128,9 +129,21 @@ func SetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 				returnInternalServerError(c, "Custom ID generation failed after 10 attempts.")
 				return
 			}
-		} else {
-			customId = *r.CustomID
-			// カスタムIDが指定されている場合、Redisに存在するか確認
+		} else { // カスタムIDが指定されている場合
+			// `/` はGinの仕様上リダイレクト時に処理されないので禁止する
+			if strings.Contains(*r.CustomID, "/") {
+				c.JSON(http.StatusBadRequest, models.APIError{
+					Type:    "invalid_request",
+					Message: "custom_id contains `/`, it isn't acceptable.",
+				})
+
+				return
+			}
+
+			// 適切にエスケープする
+			customId = url.PathEscape(*r.CustomID)
+
+			// Redisに存在するか確認
 			customIdIsExists, err := appCtx.Redis.IsExists(customId)
 			if err != nil {
 				returnInternalServerError(c, fmt.Sprintf("Redis custom ID exists error: %v", err))


### PR DESCRIPTION
- Redisに保存する際にURLをパーセントエンコーディングすることで、多くの種類のID設定に対応
- / はパス区切りとしてGinで対応できないのでID設定を禁止
- 今後API用のパス`/api`等を予約語と設定するのに備え、IDバリデーションを一般化

#23
#24
close #16

