### PR TITLE
feat: refactor controller tests to table-driven and introduce Redis interface

### DIFF
--- a/app/controllers/common_test.go
+++ b/app/controllers/common_test.go
@@ -7,13 +7,45 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	redisclient "github.com/Outtech105k/ShortUrlServer/app/redis-client"
 	"github.com/Outtech105k/ShortUrlServer/app/routes"
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/mock"
 )
+
+// MockRedisClient の定義をここに追加
+type MockRedisClient struct {
+	mock.Mock
+}
+
+func (m *MockRedisClient) SetURLRecord(id string, baseUrl string, isSandCushion bool, expireDelta *time.Duration) error {
+	args := m.Called(id, baseUrl, isSandCushion, expireDelta)
+	return args.Error(0)
+}
+
+func (m *MockRedisClient) GetBaseUrl(key string) (string, error) {
+	args := m.Called(key)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockRedisClient) GetIsNeedCusionPage(key string) (bool, error) {
+	args := m.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRedisClient) IsExists(key string) (bool, error) {
+	args := m.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRedisClient) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
 
 // テスト用の共通環境を構築
 // 戻り値: コンテキスト, miniredisインスタンス, ルーター, クリーンアップ関数
@@ -40,7 +72,7 @@ func setupTestEnvironment(t *testing.T) (utils.AppContext, *miniredis.Miniredis,
 		Config: utils.Config{
 			ServerEndpoint: "https://srv.test",
 		},
-		Redis: *adapter,
+		Redis: adapter,
 	}
 
 	router := routes.SetupRouter(appCtx)

--- a/app/controllers/geturl_test.go
+++ b/app/controllers/geturl_test.go
@@ -1,10 +1,107 @@
 package controllers_test
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/Outtech105k/ShortUrlServer/app/controllers"
+	"github.com/Outtech105k/ShortUrlServer/app/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/go-redis/redis"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestGetUrlHandler_TableDriven(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		shortUrl       string
+		setupMock      func(m *MockRedisClient)
+		expectedStatus int
+		verifyResponse func(t *testing.T, w *http.Response, body string)
+	}{
+		{
+			name:     "Success - Redirect",
+			shortUrl: "valid-id",
+			setupMock: func(m *MockRedisClient) {
+				m.On("GetBaseUrl", "valid-id").Return("https://example.com", nil).Once()
+				m.On("GetIsNeedCusionPage", "valid-id").Return(false, nil).Once()
+			},
+			expectedStatus: http.StatusFound,
+			verifyResponse: func(t *testing.T, w *http.Response, body string) {
+				assert.Equal(t, "https://example.com", w.Header.Get("Location"))
+			},
+		},
+		{
+			name:     "Success - Show Cushion",
+			shortUrl: "cushion-id",
+			setupMock: func(m *MockRedisClient) {
+				m.On("GetBaseUrl", "cushion-id").Return("https://example.com", nil).Once()
+				m.On("GetIsNeedCusionPage", "cushion-id").Return(true, nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+			verifyResponse: func(t *testing.T, w *http.Response, body string) {
+				assert.Contains(t, body, "https://example.com")
+			},
+		},
+		{
+			name:     "Error - Not Found",
+			shortUrl: "missing-id",
+			setupMock: func(m *MockRedisClient) {
+				m.On("GetBaseUrl", "missing-id").Return("", redis.Nil).Once()
+			},
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:     "Error - Redis GetBaseUrl failure",
+			shortUrl: "error-id",
+			setupMock: func(m *MockRedisClient) {
+				m.On("GetBaseUrl", "error-id").Return("", errors.New("redis error")).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:     "Error - Redis GetIsNeedCusionPage failure",
+			shortUrl: "error-cushion-id",
+			setupMock: func(m *MockRedisClient) {
+				m.On("GetBaseUrl", "error-cushion-id").Return("https://example.com", nil).Once()
+				m.On("GetIsNeedCusionPage", "error-cushion-id").Return(false, errors.New("redis error")).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRedis := new(MockRedisClient)
+			tt.setupMock(mockRedis)
+
+			appCtx := &utils.AppContext{
+				Config: utils.Config{
+					ServerEndpoint: "https://srv.test",
+				},
+				Redis: mockRedis,
+			}
+
+			// Gin のルーターにテンプレートをロードする必要がある（クッションページ用）
+			router := gin.New()
+			// テスト実行時のカレントディレクトリが app/controllers であることを想定
+			router.LoadHTMLGlob("../templates/*.html")
+			router.GET("/:shortUrl", controllers.GetUrlHandler(appCtx))
+
+			w := performRequest(router, "GET", "/"+tt.shortUrl, nil)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.verifyResponse != nil {
+				tt.verifyResponse(t, w.Result(), w.Body.String())
+			}
+			mockRedis.AssertExpectations(t)
+		})
+	}
+}
 
 func TestGetUrlHandler_Integration(t *testing.T) {
 	_, mr, router, cleanup := setupTestEnvironment(t)

--- a/app/controllers/seturl_test.go
+++ b/app/controllers/seturl_test.go
@@ -2,12 +2,228 @@ package controllers_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/Outtech105k/ShortUrlServer/app/controllers"
 	"github.com/Outtech105k/ShortUrlServer/app/models"
+	"github.com/Outtech105k/ShortUrlServer/app/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+func TestSetUrlHandler_TableDriven(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// ヘルパー: 文字列へのポインタ作成
+	ptrStr := func(s string) *string { return &s }
+	ptrBool := func(b bool) *bool { return &b }
+	ptrUint32 := func(u uint32) *uint32 { return &u }
+
+	tests := []struct {
+		name           string
+		requestBody    interface{}
+		setupMock      func(m *MockRedisClient)
+		expectedStatus int
+		verifyResponse func(t *testing.T, body []byte)
+	}{
+		{
+			name: "Success - Random ID",
+			requestBody: models.SetUrlRequest{
+				BaseURL: "https://example.com",
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", mock.Anything).Return(false, nil).Once()
+				m.On("SetURLRecord", mock.Anything, "https://example.com", false, mock.Anything).Return(nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var resp models.APIResponce
+				err := json.Unmarshal(body, &resp)
+				assert.NoError(t, err)
+				assert.Contains(t, resp.ShortURL, "https://srv.test/")
+			},
+		},
+		{
+			name: "Success - Custom ID",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				CustomID: ptrStr("my-custom-id"),
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", "my-custom-id").Return(false, nil).Once()
+				m.On("SetURLRecord", "my-custom-id", "https://example.com", false, mock.Anything).Return(nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Error - Custom ID Conflict",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				CustomID: ptrStr("existing-id"),
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", "existing-id").Return(true, nil).Once()
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name: "Error - Parameter Conflict (CustomID with UseUppercase)",
+			requestBody: models.SetUrlRequest{
+				BaseURL:      "https://example.com",
+				CustomID:     ptrStr("id"),
+				UseUppercase: ptrBool(true),
+			},
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Equal(t, "parameter_conflict", apiErr.Type)
+			},
+		},
+		{
+			name: "Error - Invalid URL",
+			requestBody: models.SetUrlRequest{
+				BaseURL: "not-a-url",
+			},
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Equal(t, "validation_error", apiErr.Type)
+			},
+		},
+		{
+			name: "Success - Custom ID Length",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				IDLength: ptrUint32(8),
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", mock.MatchedBy(func(id string) bool { return len(id) == 8 })).Return(false, nil).Once()
+				m.On("SetURLRecord", mock.MatchedBy(func(id string) bool { return len(id) == 8 }), "https://example.com", false, mock.Anything).Return(nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "Error - Custom ID contains slash",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				CustomID: ptrStr("invalid/id"),
+			},
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Contains(t, apiErr.Message, "contains `/`")
+			},
+		},
+		{
+			name: "Error - Redis IsExists failure",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				CustomID: ptrStr("id"),
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", "id").Return(false, errors.New("redis error")).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Error - Redis SetURLRecord failure",
+			requestBody: models.SetUrlRequest{
+				BaseURL:  "https://example.com",
+				CustomID: ptrStr("id"),
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", "id").Return(false, nil).Once()
+				m.On("SetURLRecord", "id", "https://example.com", false, mock.Anything).Return(errors.New("redis error")).Once()
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Error - ID generation failure (all 10 attempts exist)",
+			requestBody: models.SetUrlRequest{
+				BaseURL: "https://example.com",
+			},
+			setupMock: func(m *MockRedisClient) {
+				m.On("IsExists", mock.Anything).Return(true, nil).Times(10)
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Error - Malformed JSON",
+			requestBody: "invalid-json",
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Equal(t, "invalid_request", apiErr.Type)
+			},
+		},
+		{
+			name: "Error - Empty Body",
+			requestBody:    nil,
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Equal(t, "invalid_request", apiErr.Type)
+				assert.Equal(t, "Empty JSON body", apiErr.Message)
+			},
+		},
+		{
+			name: "Error - No character types available",
+			requestBody: models.SetUrlRequest{
+				BaseURL:      "https://example.com",
+				UseUppercase: ptrBool(false),
+				UseLowercase: ptrBool(false),
+				UseNumbers:   ptrBool(false),
+			},
+			setupMock:      func(m *MockRedisClient) {},
+			expectedStatus: http.StatusBadRequest,
+			verifyResponse: func(t *testing.T, body []byte) {
+				var apiErr models.APIError
+				json.Unmarshal(body, &apiErr)
+				assert.Equal(t, "invalid_request", apiErr.Type)
+				assert.Equal(t, "No character types available for URL ID.", apiErr.Message)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRedis := new(MockRedisClient)
+			tt.setupMock(mockRedis)
+
+			appCtx := &utils.AppContext{
+				Config: utils.Config{
+					ServerEndpoint: "https://srv.test",
+				},
+				Redis: mockRedis,
+			}
+
+			router := gin.New()
+			router.POST("/set", controllers.SetUrlHandler(appCtx))
+
+			w := performRequest(router, "POST", "/set", tt.requestBody)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.verifyResponse != nil {
+				tt.verifyResponse(t, w.Body.Bytes())
+			}
+			mockRedis.AssertExpectations(t)
+		})
+	}
+}
 
 func TestSetUrlHandler_Integration(t *testing.T) {
 	appCtx, mr, router, cleanup := setupTestEnvironment(t)

--- a/app/controllers/seturl_test.go
+++ b/app/controllers/seturl_test.go
@@ -158,8 +158,8 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 		},
 		{
-			name: "Error - Malformed JSON",
-			requestBody: "invalid-json",
+			name:           "Error - Malformed JSON",
+			requestBody:    "invalid-json",
 			setupMock:      func(m *MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
@@ -169,7 +169,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			},
 		},
 		{
-			name: "Error - Empty Body",
+			name:           "Error - Empty Body",
 			requestBody:    nil,
 			setupMock:      func(m *MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,

--- a/app/go.mod
+++ b/app/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/app/go.sum
+++ b/app/go.sum
@@ -94,6 +94,7 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/app/main.go
+++ b/app/main.go
@@ -33,7 +33,7 @@ func run() error {
 	// Setup AppContext
 	appCtx := &utils.AppContext{
 		Config: cfg,
-		Redis:  *redisAdapter,
+		Redis:  redisAdapter,
 	}
 
 	// Setup Gin Router

--- a/app/redis-client/adapter.go
+++ b/app/redis-client/adapter.go
@@ -2,9 +2,18 @@ package redisclient
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-redis/redis"
 )
+
+type RedisClient interface {
+	SetURLRecord(id string, baseUrl string, isSandCushion bool, expireDelta *time.Duration) error
+	GetBaseUrl(key string) (string, error)
+	GetIsNeedCusionPage(key string) (bool, error)
+	IsExists(key string) (bool, error)
+	Close() error
+}
 
 type RedisAdapter struct {
 	Client *redis.Client

--- a/app/utils/context.go
+++ b/app/utils/context.go
@@ -4,5 +4,5 @@ import redisclient "github.com/Outtech105k/ShortUrlServer/app/redis-client"
 
 type AppContext struct {
 	Config Config
-	Redis  redisclient.RedisAdapter
+	Redis  redisclient.RedisClient
 }


### PR DESCRIPTION
変更の概要:
   * インターフェースの導入: redisclient.RedisClient インターフェースを定義し、AppContext を具象クラスからインターフェース依存に変更（テスタビリティの向上）。
   * モックの追加: testify/mock を使用した MockRedisClient を実装し、異常系（RedisエラーやID生成失敗など）の再現を可能に。
   * コントローラーテストのリファクタリング: SetUrlHandler と GetUrlHandler をテーブル駆動テストに移行し、カバレッジを 60.4% から 90.1% へ改善。
   * ドキュメント更新: TESTING_GAPS.md に最新のカバレッジと進捗状況を反映。