### PR TITLE
Implemented router package test

### DIFF
--- a/app/controllers/common_test.go
+++ b/app/controllers/common_test.go
@@ -7,45 +7,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	redisclient "github.com/Outtech105k/ShortUrlServer/app/redis-client"
 	"github.com/Outtech105k/ShortUrlServer/app/routes"
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/mock"
 )
-
-// MockRedisClient の定義をここに追加
-type MockRedisClient struct {
-	mock.Mock
-}
-
-func (m *MockRedisClient) SetURLRecord(id string, baseUrl string, isSandCushion bool, expireDelta *time.Duration) error {
-	args := m.Called(id, baseUrl, isSandCushion, expireDelta)
-	return args.Error(0)
-}
-
-func (m *MockRedisClient) GetBaseUrl(key string) (string, error) {
-	args := m.Called(key)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockRedisClient) GetIsNeedCusionPage(key string) (bool, error) {
-	args := m.Called(key)
-	return args.Bool(0), args.Error(1)
-}
-
-func (m *MockRedisClient) IsExists(key string) (bool, error) {
-	args := m.Called(key)
-	return args.Bool(0), args.Error(1)
-}
-
-func (m *MockRedisClient) Close() error {
-	args := m.Called()
-	return args.Error(0)
-}
 
 // テスト用の共通環境を構築
 // 戻り値: コンテキスト, miniredisインスタンス, ルーター, クリーンアップ関数

--- a/app/controllers/geturl_test.go
+++ b/app/controllers/geturl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Outtech105k/ShortUrlServer/app/controllers"
+	"github.com/Outtech105k/ShortUrlServer/app/testutils"
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis"
@@ -19,14 +20,14 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 	tests := []struct {
 		name           string
 		shortUrl       string
-		setupMock      func(m *MockRedisClient)
+		setupMock      func(m *testutils.MockRedisClient)
 		expectedStatus int
 		verifyResponse func(t *testing.T, w *http.Response, body string)
 	}{
 		{
 			name:     "Success - Redirect",
 			shortUrl: "valid-id",
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("GetBaseUrl", "valid-id").Return("https://example.com", nil).Once()
 				m.On("GetIsNeedCusionPage", "valid-id").Return(false, nil).Once()
 			},
@@ -38,7 +39,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:     "Success - Show Cushion",
 			shortUrl: "cushion-id",
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("GetBaseUrl", "cushion-id").Return("https://example.com", nil).Once()
 				m.On("GetIsNeedCusionPage", "cushion-id").Return(true, nil).Once()
 			},
@@ -50,7 +51,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:     "Error - Not Found",
 			shortUrl: "missing-id",
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("GetBaseUrl", "missing-id").Return("", redis.Nil).Once()
 			},
 			expectedStatus: http.StatusNotFound,
@@ -58,7 +59,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:     "Error - Redis GetBaseUrl failure",
 			shortUrl: "error-id",
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("GetBaseUrl", "error-id").Return("", errors.New("redis error")).Once()
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -66,7 +67,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:     "Error - Redis GetIsNeedCusionPage failure",
 			shortUrl: "error-cushion-id",
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("GetBaseUrl", "error-cushion-id").Return("https://example.com", nil).Once()
 				m.On("GetIsNeedCusionPage", "error-cushion-id").Return(false, errors.New("redis error")).Once()
 			},
@@ -76,7 +77,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRedis := new(MockRedisClient)
+			mockRedis := new(testutils.MockRedisClient)
 			tt.setupMock(mockRedis)
 
 			appCtx := &utils.AppContext{

--- a/app/controllers/seturl_test.go
+++ b/app/controllers/seturl_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Outtech105k/ShortUrlServer/app/controllers"
 	"github.com/Outtech105k/ShortUrlServer/app/models"
+	"github.com/Outtech105k/ShortUrlServer/app/testutils"
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestBody    interface{}
-		setupMock      func(m *MockRedisClient)
+		setupMock      func(m *testutils.MockRedisClient)
 		expectedStatus int
 		verifyResponse func(t *testing.T, body []byte)
 	}{
@@ -35,7 +36,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			requestBody: models.SetUrlRequest{
 				BaseURL: "https://example.com",
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", mock.Anything).Return(false, nil).Once()
 				m.On("SetURLRecord", mock.Anything, "https://example.com", false, mock.Anything).Return(nil).Once()
 			},
@@ -53,7 +54,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				CustomID: ptrStr("my-custom-id"),
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", "my-custom-id").Return(false, nil).Once()
 				m.On("SetURLRecord", "my-custom-id", "https://example.com", false, mock.Anything).Return(nil).Once()
 			},
@@ -65,7 +66,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				CustomID: ptrStr("existing-id"),
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", "existing-id").Return(true, nil).Once()
 			},
 			expectedStatus: http.StatusConflict,
@@ -77,7 +78,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				CustomID:     ptrStr("id"),
 				UseUppercase: ptrBool(true),
 			},
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -90,7 +91,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			requestBody: models.SetUrlRequest{
 				BaseURL: "not-a-url",
 			},
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -104,7 +105,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				IDLength: ptrUint32(8),
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", mock.MatchedBy(func(id string) bool { return len(id) == 8 })).Return(false, nil).Once()
 				m.On("SetURLRecord", mock.MatchedBy(func(id string) bool { return len(id) == 8 }), "https://example.com", false, mock.Anything).Return(nil).Once()
 			},
@@ -116,7 +117,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				CustomID: ptrStr("invalid/id"),
 			},
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -130,7 +131,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				CustomID: ptrStr("id"),
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", "id").Return(false, errors.New("redis error")).Once()
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -141,7 +142,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				BaseURL:  "https://example.com",
 				CustomID: ptrStr("id"),
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", "id").Return(false, nil).Once()
 				m.On("SetURLRecord", "id", "https://example.com", false, mock.Anything).Return(errors.New("redis error")).Once()
 			},
@@ -152,7 +153,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			requestBody: models.SetUrlRequest{
 				BaseURL: "https://example.com",
 			},
-			setupMock: func(m *MockRedisClient) {
+			setupMock: func(m *testutils.MockRedisClient) {
 				m.On("IsExists", mock.Anything).Return(true, nil).Times(10)
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -160,7 +161,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:           "Error - Malformed JSON",
 			requestBody:    "invalid-json",
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -171,7 +172,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 		{
 			name:           "Error - Empty Body",
 			requestBody:    nil,
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -188,7 +189,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 				UseLowercase: ptrBool(false),
 				UseNumbers:   ptrBool(false),
 			},
-			setupMock:      func(m *MockRedisClient) {},
+			setupMock:      func(m *testutils.MockRedisClient) {},
 			expectedStatus: http.StatusBadRequest,
 			verifyResponse: func(t *testing.T, body []byte) {
 				var apiErr models.APIError
@@ -201,7 +202,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockRedis := new(MockRedisClient)
+			mockRedis := new(testutils.MockRedisClient)
 			tt.setupMock(mockRedis)
 
 			appCtx := &utils.AppContext{

--- a/app/routes/router_test.go
+++ b/app/routes/router_test.go
@@ -1,0 +1,78 @@
+package routes_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Outtech105k/ShortUrlServer/app/routes"
+	"github.com/Outtech105k/ShortUrlServer/app/testutils"
+	"github.com/Outtech105k/ShortUrlServer/app/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupRouter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// templates ディレクトリにアクセスできるようにディレクトリを移動
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(".."); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+	defer os.Chdir(oldWd)
+
+	mockRedis := new(testutils.MockRedisClient)
+	appCtx := &utils.AppContext{
+		Config: utils.Config{
+			ServerEndpoint: "https://srv.test",
+		},
+		Redis: mockRedis,
+	}
+
+	router := routes.SetupRouter(appCtx)
+
+	t.Run("GET / should render index.html", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "<title>") // index.html の中身があるか
+	})
+
+	t.Run("POST /set should reach SetUrlHandler", func(t *testing.T) {
+		// ハンドラーまで到達することを確認（バリデーションエラーで400が返ればルートは正しい）
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/set", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("GET /:shortUrl should reach GetUrlHandler", func(t *testing.T) {
+		mockRedis.On("GetBaseUrl", "test").Return("", nil).Once()
+		mockRedis.On("GetIsNeedCusionPage", "test").Return(false, nil).Once()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		// 302 リダイレクトまたは 404/500 ならハンドラーに到達している
+		assert.NotEqual(t, http.StatusNotFound, w.Code)
+		mockRedis.AssertExpectations(t)
+	})
+
+	t.Run("CORS configuration", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("OPTIONS", "/set", nil)
+		req.Header.Set("Origin", "http://example.com")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, w.Header().Get("Access-Control-Allow-Methods"), "POST")
+	})
+}

--- a/app/testutils/redis_mock.go
+++ b/app/testutils/redis_mock.go
@@ -1,0 +1,37 @@
+package testutils
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockRedisClient は RedisClient インターフェースのモックです。
+type MockRedisClient struct {
+	mock.Mock
+}
+
+func (m *MockRedisClient) SetURLRecord(id string, baseUrl string, isSandCushion bool, expireDelta *time.Duration) error {
+	args := m.Called(id, baseUrl, isSandCushion, expireDelta)
+	return args.Error(0)
+}
+
+func (m *MockRedisClient) GetBaseUrl(key string) (string, error) {
+	args := m.Called(key)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockRedisClient) GetIsNeedCusionPage(key string) (bool, error) {
+	args := m.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRedisClient) IsExists(key string) (bool, error) {
+	args := m.Called(key)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRedisClient) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}


### PR DESCRIPTION
- `router`パッケージで、適切にページが返されるかを検証。
- Redisのmockクライアントが別モジュールと重複するため、統合。