### PR TITLE
Modified models package tests

### DIFF
--- a/app/models/duration_test.go
+++ b/app/models/duration_test.go
@@ -33,6 +33,9 @@ func TestUnmarshalJSON(t *testing.T) {
 		{"boolean value", `true`, 0, true},
 		{"object value", `{"val":"10s"}`, 0, true},
 		{"null", `null`, 0, true},
+
+		// 異常系: 巨大な数値による Atoi 失敗
+		{"huge value", `"99999999999999999999999999s"`, 0, true},
 	}
 
 	for _, tt := range tests {

--- a/app/models/json_test.go
+++ b/app/models/json_test.go
@@ -1,0 +1,64 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Outtech105k/ShortUrlServer/app/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSON_Serialization(t *testing.T) {
+	t.Run("APIError JSON tags", func(t *testing.T) {
+		err := models.APIError{
+			Type:    "error_type",
+			Message: "error message",
+		}
+		data, _ := json.Marshal(err)
+
+		var m map[string]interface{}
+		json.Unmarshal(data, &m)
+
+		assert.Equal(t, "error_type", m["type"])
+		assert.Equal(t, "error message", m["message"])
+		assert.Nil(t, m["details"]) // omitempty の確認
+	})
+
+	t.Run("APIResponce JSON tags", func(t *testing.T) {
+		resp := models.APIResponce{
+			BaseURL:  "https://example.com",
+			ShortURL: "https://srv.test/id",
+		}
+		data, _ := json.Marshal(resp)
+
+		var m map[string]interface{}
+		json.Unmarshal(data, &m)
+
+		assert.Equal(t, "https://example.com", m["base_url"])
+		assert.Equal(t, "https://srv.test/id", m["short_url"])
+	})
+
+	t.Run("SetUrlRequest JSON tags", func(t *testing.T) {
+		// すべてのフィールドが指定された場合
+		customID := "custom"
+		useTrue := true
+		var idLen uint32 = 8
+
+		req := models.SetUrlRequest{
+			BaseURL:      "https://example.com",
+			CustomID:     &customID,
+			UseUppercase: &useTrue,
+			IDLength:     &idLen,
+		}
+		data, _ := json.Marshal(req)
+
+		var m map[string]interface{}
+		json.Unmarshal(data, &m)
+
+		assert.Equal(t, "https://example.com", m["base_url"])
+		assert.Equal(t, "custom", m["custom_id"])
+		assert.Equal(t, true, m["use_uppercase"])
+		assert.Equal(t, float64(8), m["id_length"])
+		assert.Nil(t, m["use_lowercase"]) // 指定しなかったフィールドが nil (JSON では omit される)
+	})
+}


### PR DESCRIPTION
ッケージのテストを強化し、構造体の JSON タグの検証や、API リクエスト・レスポンスの整合性を確認するテストを追加