### PR TITLE
Renew frontend UI

### DIFF
--- a/app/controllers/geturl.go
+++ b/app/controllers/geturl.go
@@ -19,9 +19,7 @@ func GetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 		if err != nil {
 			// 保存されていない(nil)場合は404を返す
 			if err == redis.Nil {
-				c.JSON(http.StatusNotFound, gin.H{
-					"error": "URL not found",
-				})
+				c.HTML(http.StatusNotFound, "notfound.html", nil)
 
 				return
 			}

--- a/app/routes/router.go
+++ b/app/routes/router.go
@@ -29,5 +29,9 @@ func SetupRouter(appCtx *utils.AppContext) *gin.Engine {
 	r.GET("/:shortUrl", controllers.GetUrlHandler(appCtx))
 	r.POST("/set", controllers.SetUrlHandler(appCtx))
 
+	r.NoRoute(func(c *gin.Context) {
+		c.HTML(http.StatusNotFound, "notfound.html", nil)
+	})
+
 	return r
 }

--- a/app/templates/cushion.html
+++ b/app/templates/cushion.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>リンクの確認</title>
+    <title>リンクの確認 - カスタムURLメーカー</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <style>
         body {
@@ -30,7 +30,7 @@
                 </p>
                 <div class="d-grid gap-2 d-md-flex justify-content-md-center mt-4">
                     <a id="goNow" href="#" class="btn btn-success">今すぐ移動</a>
-                    <a href="javascript:history.back()" class="btn btn-outline-secondary">キャンセル</a>
+                    <a href="/" class="btn btn-outline-secondary">キャンセル（トップページへ）</a>
                 </div>
                 <p class="text-muted mt-3"><small>信頼できるリンクであることを確認してください。</small></p>
             </div>
@@ -38,7 +38,7 @@
     </div>
 
     <script>
-        // クエリパラメータから遷移先URLを取得
+        // テンプレートから遷移先URLを取得
         const url = "{{.URL }}";
 
         if (!url) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,6 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>カスタムURLメーカー</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        ::placeholder {
+            color: #ccc !important;
+            opacity: 0.7; /* ブラウザごとのデフォルトを考慮 */
+        }
+    </style>
 </head>
 
 <body class="p-4">
@@ -14,7 +20,7 @@
         <form id="urlForm" class="row g-3">
             <div class="col-12">
                 <label class="form-label">元URL</label>
-                <input type="url" class="form-control" id="base_url" required>
+                <input type="url" class="form-control" id="base_url" required placeholder="https://example.com">
             </div>
 
             <div class="col-12">
@@ -102,8 +108,31 @@
         </div>
     </div>
 
+    <!-- Toast Container -->
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+        <div id="liveToast" class="toast align-items-center border-0" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="d-flex">
+                <div class="toast-body" id="toastMessage">
+                    メッセージ
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script>
+        const toastEl = document.getElementById('liveToast');
+        const toast = new bootstrap.Toast(toastEl);
+        const toastMessage = document.getElementById('toastMessage');
+
+        function showToast(message, type = 'danger') {
+            toastMessage.textContent = message;
+            toastEl.classList.remove('text-bg-success', 'text-bg-danger', 'text-bg-warning');
+            toastEl.classList.add(`text-bg-${type}`);
+            toast.show();
+        }
+
         document.addEventListener("DOMContentLoaded", () => {
             const form = document.getElementById("urlForm");
 
@@ -126,7 +155,7 @@
                 if (activeTab === "custom-tab") {
                     const customId = document.getElementById("custom_id").value.trim();
                     if (!customId) {
-                        alert("カスタムIDを入力してください。");
+                        showToast("カスタムIDを入力してください。", "warning");
                         return;
                     }
                     body.custom_id = customId;
@@ -151,16 +180,17 @@
                         document.getElementById("short_url").value = data.short_url;
                         document.getElementById("jump_link").href = data.short_url;
                         document.getElementById("result").style.display = "block";
+                        showToast("URLを生成しました！", "success");
                     } else {
                         // 特定のエラーメッセージに対するカスタム処理
                         if (data.message === "custom_id already used.") {
-                            alert("エラー: そのカスタムIDはすでに作成されています。ほかのIDを指定してください。");
+                            showToast("エラー: そのカスタムIDはすでに使用されています。", "danger");
                         } else {
-                            alert("エラー: " + data.message);
+                            showToast("エラー: " + data.message, "danger");
                         }
                     }
                 } catch (err) {
-                    alert("リクエスト失敗: " + err.message);
+                    showToast("リクエスト失敗: " + err.message, "danger");
                 }
             });
         });
@@ -192,7 +222,7 @@
                 showFeedback(btn, originalText);
             } catch (err) {
                 console.error("Fallback copy failed:", err);
-                alert("コピーに失敗しました。手動でコピーしてください。");
+                showToast("コピーに失敗しました。手動でコピーしてください。", "danger");
             }
             // 選択を解除
             window.getSelection().removeAllRanges();

--- a/app/templates/notfound.html
+++ b/app/templates/notfound.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>404 Not Found - カスタムURLメーカー</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            background-color: #f8f9fa;
+        }
+
+        .error-box {
+            max-width: 600px;
+            margin: 15vh auto;
+            padding: 2rem;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container text-center">
+        <div class="card shadow error-box">
+            <div class="card-body">
+                <h1 class="display-1 text-muted">404</h1>
+                <h4 class="card-title mb-3">ページが見つかりません</h4>
+                <p class="card-text text-muted">
+                    指定されたURLは存在しないか、有効期限が切れている可能性があります。<br>
+                    URLが正しいか確認してください。
+                </p>
+                <div class="mt-4">
+                    <a href="/" class="btn btn-primary">トップページに戻る</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
- 404ページのHTML化
- クッションページのキャンセル遷移先を`/`に変更
- 作成ページでのトースト・プレースホルダーの設定