### PR TITLE
Implement OGP responding

### DIFF
--- a/app/controllers/common_test.go
+++ b/app/controllers/common_test.go
@@ -57,7 +57,7 @@ func setupTestEnvironment(t *testing.T) (utils.AppContext, *miniredis.Miniredis,
 }
 
 // HTTPリクエストを実行してレスポンスを返す
-func performRequest(router *gin.Engine, method, path string, body interface{}) *httptest.ResponseRecorder {
+func performRequest(router *gin.Engine, method, path string, headers map[string]string, body interface{}) *httptest.ResponseRecorder {
 	var buf *bytes.Buffer
 	if body != nil {
 		b, _ := json.Marshal(body)
@@ -70,6 +70,9 @@ func performRequest(router *gin.Engine, method, path string, body interface{}) *
 	req, _ := http.NewRequest(method, path, buf)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	router.ServeHTTP(w, req)
 	return w

--- a/app/controllers/control_test.go
+++ b/app/controllers/control_test.go
@@ -24,7 +24,7 @@ func TestControlUrlHandler(t *testing.T) {
 		mr.HSet(shortUrl, "base_url", ts.URL)
 		mr.HSet(shortUrl, "public_ctrl", "true")
 
-		w := performRequest(router, "GET", "/"+shortUrl+"/control", nil)
+		w := performRequest(router, "GET", "/"+shortUrl+"/control", nil, nil)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "Mock Title")
@@ -37,14 +37,14 @@ func TestControlUrlHandler(t *testing.T) {
 		mr.HSet(shortUrl, "base_url", "https://example.com")
 		mr.HSet(shortUrl, "public_ctrl", "false")
 
-		w := performRequest(router, "GET", "/"+shortUrl+"/control", nil)
+		w := performRequest(router, "GET", "/"+shortUrl+"/control", nil, nil)
 
 		assert.Equal(t, http.StatusForbidden, w.Code)
 		assert.Contains(t, w.Body.String(), "このURLの管理画面は非公開です。")
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
-		w := performRequest(router, "GET", "/nonexistent/control", nil)
+		w := performRequest(router, "GET", "/nonexistent/control", nil, nil)
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})

--- a/app/controllers/geturl.go
+++ b/app/controllers/geturl.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/Outtech105k/ShortUrlServer/app/utils"
 	"github.com/gin-gonic/gin"
@@ -43,16 +45,60 @@ func GetUrlHandler(appCtx *utils.AppContext) gin.HandlerFunc {
 			return
 		}
 
-		if isCushionRequired {
-			// クッションページを表示
-			c.HTML(http.StatusOK, "cushion.html", gin.H{
-				"URL": baseUrl,
-			})
+		// Bot判定（OGP取得用）
+		userAgent := c.GetHeader("User-Agent")
+		isBot := isBotUserAgent(userAgent)
 
+		if isCushionRequired {
+			// クッションページを表示（ネタバレ防止OGP）
+			c.HTML(http.StatusOK, "cushion.html", gin.H{
+				"URL":            baseUrl,
+				"FullShortURL":   fmt.Sprintf("%s/%s", appCtx.Config.ServerEndpoint, shortUrl),
+				"ServerEndpoint": appCtx.Config.ServerEndpoint,
+			})
+			return
+		}
+
+		if isBot {
+			// クッションページなしだがBotの場合：リダイレクト先のOGPを返す
+			ogp, err := utils.FetchOGPInfo(baseUrl)
+			if err != nil {
+				log.Printf("Failed to fetch OGP for bot redirect: %v", err)
+				// 失敗時は最低限の情報で返す
+			}
+
+			c.HTML(http.StatusOK, "direct_ogp.html", gin.H{
+				"URL":            baseUrl,
+				"FullShortURL":   fmt.Sprintf("%s/%s", appCtx.Config.ServerEndpoint, shortUrl),
+				"OGPTitle":       ogp.Title,
+				"OGPDescription": ogp.Description,
+				"OGPImage":       ogp.Image,
+			})
 			return
 		}
 
 		// クッションページなしでリダイレクト
 		c.Redirect(http.StatusFound, baseUrl)
 	}
+}
+
+func isBotUserAgent(ua string) bool {
+	ua = strings.ToLower(ua)
+	bots := []string{
+		"bot",
+		"crawler",
+		"spider",
+		"facebookexternalhit",
+		"twitterbot",
+		"slackbot",
+		"discordbot",
+		"whatsapp",
+		"line-poker",
+	}
+	for _, bot := range bots {
+		if strings.Contains(ua, bot) {
+			return true
+		}
+	}
+	return false
 }

--- a/app/controllers/geturl_test.go
+++ b/app/controllers/geturl_test.go
@@ -20,6 +20,7 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 	tests := []struct {
 		name           string
 		shortUrl       string
+		userAgent      string
 		setupMock      func(m *testutils.MockRedisClient)
 		expectedStatus int
 		verifyResponse func(t *testing.T, w *http.Response, body string)
@@ -46,6 +47,38 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			verifyResponse: func(t *testing.T, w *http.Response, body string) {
 				assert.Contains(t, body, "https://example.com")
+				// OGPタグの確認（クッションページ用）
+				assert.Contains(t, body, "<meta property=\"og:title\" content=\"リンクの確認 - URL Forge\" />")
+				assert.Contains(t, body, "<meta property=\"og:description\" content=\"この先は外部サイトです。リンクを確認して移動してください。\" />")
+			},
+		},
+		{
+			name:      "Bot - Direct OGP when cushion disabled",
+			shortUrl:  "bot-id",
+			userAgent: "Twitterbot/1.0",
+			setupMock: func(m *testutils.MockRedisClient) {
+				m.On("GetBaseUrl", "bot-id").Return("https://example.com", nil).Once()
+				m.On("GetIsNeedCusionPage", "bot-id").Return(false, nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+			verifyResponse: func(t *testing.T, w *http.Response, body string) {
+				// リダイレクト先のOGPを模した中間ページが表示されるはず
+				assert.Contains(t, body, "https://example.com")
+				assert.Contains(t, body, "<meta http-equiv=\"refresh\" content=\"0;url=https://example.com\">")
+			},
+		},
+		{
+			name:      "Bot - Cushion OGP when cushion enabled",
+			shortUrl:  "bot-cushion-id",
+			userAgent: "Slackbot 1.0",
+			setupMock: func(m *testutils.MockRedisClient) {
+				m.On("GetBaseUrl", "bot-cushion-id").Return("https://example.com", nil).Once()
+				m.On("GetIsNeedCusionPage", "bot-cushion-id").Return(true, nil).Once()
+			},
+			expectedStatus: http.StatusOK,
+			verifyResponse: func(t *testing.T, w *http.Response, body string) {
+				// クッションページのOGPが表示される
+				assert.Contains(t, body, "<meta property=\"og:title\" content=\"リンクの確認 - URL Forge\" />")
 			},
 		},
 		{
@@ -93,7 +126,11 @@ func TestGetUrlHandler_TableDriven(t *testing.T) {
 			router.LoadHTMLGlob("../templates/*.html")
 			router.GET("/:shortUrl", controllers.GetUrlHandler(appCtx))
 
-			w := performRequest(router, "GET", "/"+tt.shortUrl, nil)
+			var headers map[string]string
+			if tt.userAgent != "" {
+				headers = map[string]string{"User-Agent": tt.userAgent}
+			}
+			w := performRequest(router, "GET", "/"+tt.shortUrl, headers, nil)
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			if tt.verifyResponse != nil {
@@ -115,7 +152,7 @@ func TestGetUrlHandler_Integration(t *testing.T) {
 		mr.HSet(shortUrl, "base_url", baseUrl)
 		mr.HSet(shortUrl, "cushion", "false")
 
-		w := performRequest(router, "GET", "/"+shortUrl, nil)
+		w := performRequest(router, "GET", "/"+shortUrl, nil, nil)
 
 		if w.Code != http.StatusFound {
 			t.Errorf("expected status 302, got %d", w.Code)
@@ -132,7 +169,7 @@ func TestGetUrlHandler_Integration(t *testing.T) {
 		mr.HSet(shortUrl, "base_url", baseUrl)
 		mr.HSet(shortUrl, "cushion", "true")
 
-		w := performRequest(router, "GET", "/"+shortUrl, nil)
+		w := performRequest(router, "GET", "/"+shortUrl, nil, nil)
 
 		if w.Code != http.StatusOK {
 			t.Errorf("expected status 200, got %d", w.Code)
@@ -143,7 +180,7 @@ func TestGetUrlHandler_Integration(t *testing.T) {
 	})
 
 	t.Run("Not Found", func(t *testing.T) {
-		w := performRequest(router, "GET", "/unknown", nil)
+		w := performRequest(router, "GET", "/unknown", nil, nil)
 
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected status 404, got %d", w.Code)

--- a/app/controllers/seturl_test.go
+++ b/app/controllers/seturl_test.go
@@ -241,7 +241,7 @@ func TestSetUrlHandler_TableDriven(t *testing.T) {
 			router := gin.New()
 			router.POST("/api/set", controllers.SetUrlHandler(appCtx))
 
-			w := performRequest(router, "POST", "/api/set", tt.requestBody)
+			w := performRequest(router, "POST", "/api/set", nil, tt.requestBody)
 
 			assert.Equal(t, tt.expectedStatus, w.Code)
 			if tt.verifyResponse != nil {
@@ -260,7 +260,7 @@ func TestSetUrlHandler_Integration(t *testing.T) {
 		reqBody := models.SetUrlRequest{
 			BaseURL: "https://example.com/original",
 		}
-		w := performRequest(router, "POST", "/api/set", reqBody)
+		w := performRequest(router, "POST", "/api/set", nil, reqBody)
 
 		if w.Code != http.StatusOK {
 			t.Errorf("expected status 200, got %d", w.Code)
@@ -284,7 +284,7 @@ func TestSetUrlHandler_Integration(t *testing.T) {
 			BaseURL:  "https://example.com/custom",
 			CustomID: &customId,
 		}
-		w := performRequest(router, "POST", "/api/set", reqBody)
+		w := performRequest(router, "POST", "/api/set", nil, reqBody)
 
 		if w.Code != http.StatusOK {
 			t.Errorf("expected status 200, got %d", w.Code)
@@ -307,7 +307,7 @@ func TestSetUrlHandler_Integration(t *testing.T) {
 			BaseURL:  "https://example.com/new",
 			CustomID: &existingId,
 		}
-		w := performRequest(router, "POST", "/api/set", reqBody)
+		w := performRequest(router, "POST", "/api/set", nil, reqBody)
 
 		if w.Code != http.StatusConflict {
 			t.Errorf("expected status 409, got %d", w.Code)
@@ -318,7 +318,7 @@ func TestSetUrlHandler_Integration(t *testing.T) {
 		reqBody := models.SetUrlRequest{
 			BaseURL: "not-a-url",
 		}
-		w := performRequest(router, "POST", "/api/set", reqBody)
+		w := performRequest(router, "POST", "/api/set", nil, reqBody)
 
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("expected status 400, got %d", w.Code)

--- a/app/templates/cushion.html
+++ b/app/templates/cushion.html
@@ -4,7 +4,16 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>リンクの確認 - カスタムURLメーカー</title>
+    <title>リンクの確認 - URL Forge</title>
+
+    <!-- OGP Tags -->
+    <meta property="og:title" content="リンクの確認 - URL Forge" />
+    <meta property="og:description" content="この先は外部サイトです。リンクを確認して移動してください。" />
+    <meta property="og:image" content="{{.ServerEndpoint}}/static/images/URL-Forge-story.png" />
+    <meta property="og:url" content="{{.FullShortURL}}" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <style>
         body {

--- a/app/templates/direct_ogp.html
+++ b/app/templates/direct_ogp.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{if .OGPTitle}}{{.OGPTitle}}{{else}}Redirecting...{{end}}</title>
+
+    <!-- OGP Tags -->
+    <meta property="og:title" content="{{if .OGPTitle}}{{.OGPTitle}}{{else}}Redirecting...{{end}}" />
+    <meta property="og:description" content="{{if .OGPDescription}}{{.OGPDescription}}{{else}}You are being redirected to {{.URL}}{{end}}" />
+    {{if .OGPImage}}<meta property="og:image" content="{{.OGPImage}}" />{{end}}
+    <meta property="og:url" content="{{.FullShortURL}}" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+
+    <meta http-equiv="refresh" content="0;url={{.URL}}">
+</head>
+
+<body>
+    <p>Redirecting to <a href="{{.URL}}">{{.URL}}</a>...</p>
+</body>
+
+</html>


### PR DESCRIPTION
- クッションページの有無にかかわらず、適切なOGPを返せるように変更。
  - クッションなしならリダイレクト先のOGPを横流しする。
  - クッションありならクッションページ独自のOGPを返す。